### PR TITLE
Drop IE support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "bulma": "0.7.5",
-    "core-js": "3.2.1",
     "normalize.css": "8.0.1",
     "react": "16.9.0",
     "react-dom": "16.9.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import 'core-js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import 'bulma/css/bulma.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4090,11 +4090,6 @@ core-js@3.1.4, core-js@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.4.tgz#3a2837fc48e582e1ae25907afcd6cf03b0cc7a07"
   integrity sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==
 
-core-js@3.2.1, core-js@^3.0.1, core-js@^3.0.4:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
-  integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -4109,6 +4104,11 @@ core-js@^2.6.5:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+
+core-js@^3.0.1, core-js@^3.0.4:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
+  integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
The biggest bundle size reduced 47.0% from 283,748 to 150,477 bytes.

![image](https://user-images.githubusercontent.com/3375461/63824262-5a667c80-c90b-11e9-9586-9b0a427e3c61.png)

![image](https://user-images.githubusercontent.com/3375461/63824449-ff815500-c90b-11e9-82e2-4d2935684b08.png)
