### PR TITLE
chore(security): disable graphql introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ A minimalist app. A cutting-edge technology lab. An automation experiment.
 - **graphql-upload** - GraphQL upload
 - **graphql-shield** - GraphQL permissions
 - **graphql-depth-limit** - GraphQL depth limit
+- **graphql-disable-introspection** - Disable GraphQL introspection
 - **graphql-query-complexity** - GraphQL query complexity analysis
 - **DataLoader** - Batching and caching
 - **Knex.js** - SQL query builder

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -35,6 +35,7 @@
         "faker": "5.5.3",
         "graphql": "15.5.0",
         "graphql-depth-limit": "1.1.0",
+        "graphql-disable-introspection": "1.2.0",
         "graphql-middleware": "6.0.10",
         "graphql-query-complexity": "0.8.1",
         "graphql-shield": "7.5.0",
@@ -10286,6 +10287,14 @@
       },
       "peerDependencies": {
         "graphql": "*"
+      }
+    },
+    "node_modules/graphql-disable-introspection": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-disable-introspection/-/graphql-disable-introspection-1.2.0.tgz",
+      "integrity": "sha512-bRY1LWCOzho/snYsLZ0N2J78zgCDtcFdbdZILxWGi8TifLLYf2bHZ3yw5r1NX42K87AMEOT0d11XScVrcJ+Zig==",
+      "peerDependencies": {
+        "graphql": "^0.9.2 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/graphql-middleware": {
@@ -31684,6 +31693,11 @@
       "requires": {
         "arrify": "^1.0.1"
       }
+    },
+    "graphql-disable-introspection": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-disable-introspection/-/graphql-disable-introspection-1.2.0.tgz",
+      "integrity": "sha512-bRY1LWCOzho/snYsLZ0N2J78zgCDtcFdbdZILxWGi8TifLLYf2bHZ3yw5r1NX42K87AMEOT0d11XScVrcJ+Zig=="
     },
     "graphql-middleware": {
       "version": "6.0.10",

--- a/api/package.json
+++ b/api/package.json
@@ -54,6 +54,7 @@
     "faker": "5.5.3",
     "graphql": "15.5.0",
     "graphql-depth-limit": "1.1.0",
+    "graphql-disable-introspection": "1.2.0",
     "graphql-middleware": "6.0.10",
     "graphql-query-complexity": "0.8.1",
     "graphql-shield": "7.5.0",

--- a/api/src/graphQL/middlewares/graphQLMiddleware.ts
+++ b/api/src/graphQL/middlewares/graphQLMiddleware.ts
@@ -1,5 +1,8 @@
 import { graphqlHTTP } from 'express-graphql';
 import depthLimit from 'graphql-depth-limit';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import NoIntrospection from 'graphql-disable-introspection';
 import { applyMiddleware } from 'graphql-middleware';
 import queryComplexity, { simpleEstimator } from 'graphql-query-complexity';
 import logger from '../../log/utils/logger';
@@ -29,6 +32,7 @@ const graphQLMiddleware = graphqlHTTP((req, res, params) => {
     },
     schema: applyMiddleware(schema, permissions),
     validationRules: [
+      NoIntrospection,
       depthLimit(5),
       queryComplexity({
         estimators: [simpleEstimator({ defaultComplexity: 1 })],


### PR DESCRIPTION
```
query IntrospectionQuery {
  __schema {
    queryType {
      name
    }
    mutationType {
      name
    }
    subscriptionType {
      name
    }
    types {
      ...FullType
    }
    directives {
      name
      description

      locations
      args {
        ...InputValue
      }
    }
  }
}

fragment FullType on __Type {
  kind
  name
  description
  fields(includeDeprecated: true) {
    name
    description
    args {
      ...InputValue
    }
    type {
      ...TypeRef
    }
    isDeprecated
    deprecationReason
  }
  inputFields {
    ...InputValue
  }
  interfaces {
    ...TypeRef
  }
  enumValues(includeDeprecated: true) {
    name
    description
    isDeprecated
    deprecationReason
  }
  possibleTypes {
    ...TypeRef
  }
}

fragment InputValue on __InputValue {
  name
  description
  type {
    ...TypeRef
  }
  defaultValue
}

fragment TypeRef on __Type {
  kind
  name
  ofType {
    kind
    name
    ofType {
      kind
      name
      ofType {
        kind
        name
        ofType {
          kind
          name
          ofType {
            kind
            name
            ofType {
              kind
              name
              ofType {
                kind
                name
              }
            }
          }
        }
      }
    }
  }
}
```
now will return:

![image](https://user-images.githubusercontent.com/3375461/120711234-b7845e80-c4f1-11eb-88a7-baf1f78ea094.png)
