### PR TITLE
chore(hm-opal-client): bump asyncpg version to 0.24.0

### DIFF
--- a/api-node/Dockerfile
+++ b/api-node/Dockerfile
@@ -22,7 +22,7 @@ RUN npm run build \
 
 
 FROM base AS release
-RUN apk add --no-cache dumb-init=1.2.5-r0
+RUN apk add --no-cache dumb-init=1.2.5-r1
 ENV NODE_ENV production
 USER node
 

--- a/hm-opal-client/Dockerfile
+++ b/hm-opal-client/Dockerfile
@@ -4,4 +4,9 @@ FROM authorizon/opal-client:0.1.12
 WORKDIR /usr/src/app
 
 COPY ["hm-opal-client/", "./"]
-RUN python setup.py install
+
+RUN apk update \
+  && apk add --no-cache gcc=9.3.0-r0 libc-dev=0.7.2-r0 \
+  && python setup.py install \
+  && apk del gcc libc-dev \
+  && rm -rf /var/cache/apk

--- a/hm-opal-client/requirements.txt
+++ b/hm-opal-client/requirements.txt
@@ -1,4 +1,4 @@
 opal-common==0.1.12
-asyncpg==0.23.0
+asyncpg==0.24.0
 pydantic==1.8.2
 tenacity==6.3.1


### PR DESCRIPTION
Cannot use latest `gcc=10.3.1_git20210625-r0` due to limitation.

Close #3225