### PR TITLE
chore(ios): enable code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -602,7 +602,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 'latest-stable'
       - name: Build
         working-directory: mobile-ios
         run: |
@@ -617,6 +617,22 @@ jobs:
             -project HMMobile.xcodeproj \
             -scheme HMMobile \
             -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=16.1"
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.3'
+      - name: Install dependencies
+        working-directory: mobile-ios
+        run: |
+          bundle install
+      - name: Convert coverage to llvm-cov format
+        working-directory: mobile-ios
+        run: |
+          bundle exec slather
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: mobile-ios
 
   api-go-test:
     name: API (Go) - Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -592,6 +592,9 @@ jobs:
     name: Mobile (iOS) - Test
     runs-on: macos-12
     timeout-minutes: 30
+    env:
+      # https://github.com/ruby/setup-ruby#matrix-of-gemfiles
+      BUNDLE_GEMFILE: ${{ github.workspace }}/mobile-ios/Gemfile
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -603,6 +606,11 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 'latest-stable'
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.3'
+          bundler-cache: true
       - name: Build
         working-directory: mobile-ios
         run: |
@@ -617,14 +625,6 @@ jobs:
             -project HMMobile.xcodeproj \
             -scheme HMMobile \
             -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=16.1"
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.1.3'
-      - name: Install dependencies
-        working-directory: mobile-ios
-        run: |
-          bundle install
       - name: Convert coverage to llvm-cov format
         working-directory: mobile-ios
         run: |

--- a/mobile-ios/.slather.yml
+++ b/mobile-ios/.slather.yml
@@ -1,0 +1,3 @@
+xcodeproj: HMMobile.xcodeproj
+scheme: HMMobile
+coverage_service: cobertura_xml

--- a/mobile-ios/Gemfile
+++ b/mobile-ios/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "slather", "2.7.3"

--- a/mobile-ios/Gemfile.lock
+++ b/mobile-ios/Gemfile.lock
@@ -1,0 +1,50 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.5)
+      rexml
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    atomos (0.1.3)
+    claide (1.1.0)
+    clamp (1.3.2)
+    colored2 (3.1.2)
+    concurrent-ruby (1.1.10)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.16.3)
+    nanaimo (0.3.0)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-darwin)
+      racc (~> 1.4)
+    racc (1.6.0)
+    rexml (3.2.5)
+    slather (2.7.3)
+      CFPropertyList (>= 2.2, < 4)
+      activesupport
+      clamp (~> 1.3)
+      nokogiri (>= 1.13.9)
+      xcodeproj (~> 1.21)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    xcodeproj (1.22.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (~> 3.2.4)
+
+PLATFORMS
+  arm64-darwin-22
+  x86_64-darwin-19
+
+DEPENDENCIES
+  slather (= 2.7.3)
+
+BUNDLED WITH
+   2.3.26

--- a/mobile-ios/HMMobile.xcodeproj/xcshareddata/xcschemes/HMMobile.xcscheme
+++ b/mobile-ios/HMMobile.xcodeproj/xcshareddata/xcschemes/HMMobile.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6AD5753B292C8324006C70BB"
+               BuildableName = "HMMobile.app"
+               BlueprintName = "HMMobile"
+               ReferencedContainer = "container:HMMobile.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6AD5754B292C8325006C70BB"
+               BuildableName = "HMMobileTests.xctest"
+               BlueprintName = "HMMobileTests"
+               ReferencedContainer = "container:HMMobile.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6AD57555292C8325006C70BB"
+               BuildableName = "HMMobileUITests.xctest"
+               BlueprintName = "HMMobileUITests"
+               ReferencedContainer = "container:HMMobile.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6AD5753B292C8324006C70BB"
+            BuildableName = "HMMobile.app"
+            BlueprintName = "HMMobile"
+            ReferencedContainer = "container:HMMobile.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6AD5753B292C8324006C70BB"
+            BuildableName = "HMMobile.app"
+            BlueprintName = "HMMobile"
+            ReferencedContainer = "container:HMMobile.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/mobile-ios/Makefile
+++ b/mobile-ios/Makefile
@@ -13,3 +13,14 @@ build-test:
 		-project HMMobile.xcodeproj \
 		-scheme HMMobile \
 		-destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=16.1"
+
+bundle-init:
+	bundle init
+bundle-install:
+	bundle install
+bundle-exec-test-coverage:
+	bundle exec slather
+bundle-update:
+	bundle update
+bundle-lock:
+	bundle lock --add-platform x86_64-darwin-19


### PR DESCRIPTION
## 1. Generate **xcscheme** file
The new HMMobile.xcscheme file is generated by Xcode after selecting
<img width="1628" alt="image" src="https://user-images.githubusercontent.com/3375461/204123794-fb86fde3-5b09-4ed5-8f76-830164d1ca9f.png">
<img width="933" alt="image" src="https://user-images.githubusercontent.com/3375461/204123804-c50e8608-da79-4045-a67b-ba084a30b7fd.png">

## 2. Notes for **slather**
**slather** supports

```
--simple-output, -s                      Output coverage results to the terminal
--gutter-json, -g                        Output coverage results as Gutter JSON format
--cobertura-xml, -x                      Output coverage results as Cobertura XML format
--sonarqube-xml, -sq                     Output coverage results as SonarQube XML format
--llvm-cov, -r                           Output coverage as llvm-cov format
--json                                   Output coverage results as simple JSON
--html                                   Output coverage results as static html pages
```

- (Skipped) `simple-output` only prints in terminal, so skip.
- (Failed) `gutter-json`, `llvm-cov`, `json`, `html`: Codecov failed to identify these format reports.
- (Failed) `sonarqube-xml` Codecov can identify this format report and shows [succeed uploading](https://github.com/Hongbo-Miao/hongbomiao.com/actions/runs/3557062847/jobs/5974831521), but failed showing in the [Codecov UI](https://app.codecov.io/github/Hongbo-Miao/hongbomiao.com/commit/92f39ee6bb9c4cf4629065d9fc97430864b89966) eventually (maybe because of some parsing issue?):

  <details>
    <summary>GitHub Action log</summary>
    
    ```shell
  ==> macos OS detected
  https://uploader.codecov.io/latest/macos/codecov.SHA256SUM
  ==> SHASUM file signed by key id 806bb28aed77[9](https://github.com/Hongbo-Miao/hongbomiao.com/actions/runs/3557062847/jobs/5974831521#step:12:10)869
  ==> Uploader SHASUM verified (ccc032e70958ea3eca9bd15c7fdad5bbacc279c3bab22f227417573356569666  codecov)
  ==> Running version latest
  ==> Running version v0.3.2
  /Users/runner/work/_actions/codecov/codecov-action/v3/dist/codecov -n  -Q github-action-3.1.1 -C 92f39ee6bb9c4cf4629065d9fc97430864b89966 -s mobile-ios
  [2022-11-27T06:40:18.219Z] ['info'] 
       _____          _
      / ____|        | |
     | |     ___   __| | ___  ___ _____   __
     | |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
     | |___| (_) | (_| |  __/ (_| (_) \ V /
      \_____\___/ \__,_|\___|\___\___/ \_/
  
    Codecov report uploader 0.3.2
  [2022-11-27T06:40:18.295Z] ['info'] => Project root located at: /Users/runner/work/hongbomiao.com/hongbomiao.com
  [2022-11-27T06:40:18.297Z] ['info'] -> No token specified or token is empty
  [2022-11-27T06:40:18.327Z] ['info'] Searching for coverage files...
  [2022-11-27T06:40:18.381Z] ['info'] Warning: Some files located via search were excluded from upload.
  [2022-11-27T06:40:18.381Z] ['info'] If Codecov did not locate your files, please review https://docs.codecov.com/docs/supported-report-formats
  [2022-11-27T06:40:18.381Z] ['info'] => Found 1 possible coverage files:
    sonarqube-generic-coverage.xml
  [2022-11-27T06:40:18.381Z] ['info'] Processing mobile-ios/sonarqube-generic-coverage.xml...
  [2022-11-27T06:40:18.385Z] ['info'] Detected GitHub Actions as the CI provider.
  [2022-11-27T06:40:18.387Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=github-action-3.1.1-uploader-0.3.2&token=*******&branch=sonarqube-xml&build=3557062847&build_url=https%3A%2F%2Fgithub.com%2FHongbo-Miao%2Fhongbomiao.com%2Factions%2Fruns%2F3557062847&commit=92f39ee6bb9c4cf4629065d9fc97430864b89966&job=Test&pr=6135&service=github-actions&slug=Hongbo-Miao%2Fhongbomiao.com&name=&tag=&flags=&parent=
  [2022-11-27T06:40:18.964Z] ['info'] https://app.codecov.io/github/Hongbo-Miao/hongbomiao.com/commit/92f39ee6bb9c4cf4629065d9fc97430864b89966
  https://storage.googleapis.com/codecov/v4/raw/2022-11-27/C979CA27A1BD5F2D480AB04BE26CD93E/92f39ee6bb9c4cf4629065d9fc97430864b89966/a4dfe2e9-23cc-4920-8cdd-8c93affeef29.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=GOOG1EJOGFN2JQ4OCTGA2MU5AEIT7OT5Z7HTFOAN2SPG4NWSN2UJYOY5U6LZQ%2F20221127%2FUS%2Fs3%2Faws4_request&X-Amz-Date=20221127T064018Z&X-Amz-Expires=[10](https://github.com/Hongbo-Miao/hongbomiao.com/actions/runs/3557062847/jobs/5974831521#step:12:11)&X-Amz-SignedHeaders=host&X-Amz-Signature=6624e605d68f09ea46be141a6d2329314066c3ed025a4560e7315b729f7c4e15
  [2022-[11](https://github.com/Hongbo-Miao/hongbomiao.com/actions/runs/3557062847/jobs/5974831521#step:12:12)-27T06:40:[18](https://github.com/Hongbo-Miao/hongbomiao.com/actions/runs/3557062847/jobs/5974831521#step:12:19).965Z] ['info'] Uploading...
  [2022-11-27T06:40:[19](https://github.com/Hongbo-Miao/hongbomiao.com/actions/runs/3557062847/jobs/5974831521#step:12:20).[21](https://github.com/Hongbo-Miao/hongbomiao.com/actions/runs/3557062847/jobs/5974831521#step:12:22)9Z] ['info'] {"status":"success","resultURL":"https://app.codecov.io/github/Hongbo-Miao/hongbomiao.com/commit/92f39ee6bb9c4cf46[29](https://github.com/Hongbo-Miao/hongbomiao.com/actions/runs/3557062847/jobs/5974831521#step:12:30)065d9fc974[30](https://github.com/Hongbo-Miao/hongbomiao.com/actions/runs/3557062847/jobs/5974831521#step:12:31)864b89966"}
    ```
  </details>
  <img width="1551" alt="image" src="https://user-images.githubusercontent.com/3375461/204167539-3b5414e6-3a15-4fa4-af22-725292f64a64.png">
- (Succeed) `cobertura-xml`: Codecov can identify this format report successfully, and shows well in the [Codecov UI](https://app.codecov.io/github/Hongbo-Miao/hongbomiao.com/pull/6134).
  <img width="1036" alt="image" src="https://user-images.githubusercontent.com/3375461/204167900-da60f4a0-eea7-450b-9911-b010852c203f.png">
  <img width="1035" alt="image" src="https://user-images.githubusercontent.com/3375461/204167925-bfe4024f-675c-48f0-b3a6-43e5f912cb43.png">


