### PR TITLE
feat(api-node): add gfx687/express-request-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The diagram illustrates the repository's architecture, which is considered overl
 - **Helmet** - HTTP header `Content-Security-Policy`, `Referrer-Policy`, `Strict-Transport-Security`, `X-Content-Type-Options`, `X-DNS-Prefetch-Control`, `X-Download-Options`, `X-Frame-Options`, `X-Permitted-Cross-Domain-Policies`, `X-XSS-Protection`
 - **Report To** - HTTP header `Report-To`
 - **Network Error Logging** - HTTP header `NEL`
+- **express-request-id** - HTTP header `X-Request-ID`
 - **response-time** - HTTP header `X-Response-Time`
 - **connect-timeout** - Request timeout
 - **request-ip** - IP address retrieving

--- a/api-node/package-lock.json
+++ b/api-node/package-lock.json
@@ -7,6 +7,7 @@
       "name": "hm-api-node",
       "dependencies": {
         "@faker-js/faker": "9.3.0",
+        "@gfx687/express-request-id": "1.0.3",
         "@godaddy/terminus": "4.12.1",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.56.0",
@@ -1268,6 +1269,14 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=9.0.0"
+      }
+    },
+    "node_modules/@gfx687/express-request-id": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gfx687/express-request-id/-/express-request-id-1.0.3.tgz",
+      "integrity": "sha512-12Ishyzm4AjHm1dxAF8MtoLfXUDkkLjNHHBOxTT44R1rV/aoP3Nj40vnXvqiu8oNAgfsLQowFf3aR07H2ntYEA==",
+      "peerDependencies": {
+        "express": "^4.18.2"
       }
     },
     "node_modules/@godaddy/terminus": {
@@ -2793,18 +2802,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/api-logs": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.55.0.tgz",
-      "integrity": "sha512-3cpa+qI45VHYcA5c0bHM6VHo9gicv3p5mlLHNG3rLyjQU8b7e0st1rWtrUn3JbZ3DwwCfhKop4eQ9UuYlC6Pkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {

--- a/api-node/package.json
+++ b/api-node/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "9.3.0",
+    "@gfx687/express-request-id": "1.0.3",
     "@godaddy/terminus": "4.12.1",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.56.0",

--- a/api-node/src/app.ts
+++ b/api-node/src/app.ts
@@ -1,3 +1,4 @@
+import { requestID } from "@gfx687/express-request-id";
 import * as Sentry from '@sentry/node';
 import cookieParser from 'cookie-parser';
 import express from 'express';
@@ -27,6 +28,7 @@ const app = express()
   .use(reportToMiddleware())
   .use(networkErrorLoggingMiddleware())
   .use(helmetMiddleware())
+  .use(requestID())
   .use(responseTime())
   .use(indexRouter)
   .use(favicon('public/favicon.ico'))


### PR DESCRIPTION
Found another package https://github.com/gfx687/express-request-id using `import { randomUUID } from "crypto";`
It is 3 times faster compared to https://github.com/floatdrop/express-request-id using `import { v4 } from 'uuid';`
