### PR TITLE
ci(api-node): switch to render hook url method to deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1048,8 +1048,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Deploy to Render
-        uses: johnbeynon/render-deploy-action@v0.0.8
-        with:
-          service-id: ${{ secrets.MY_RENDER_SERVICE_ID }}
-          api-key: ${{ secrets.MY_RENDER_API_KEY }}
-          wait-for-success: true
+        env:
+          render_deploy_hook_url: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          curl "$render_deploy_hook_url"


### PR DESCRIPTION
Just found out GitHub Action https://github.com/johnbeynon/render-deploy-action is not active maintained.
Switch to official [Render hook URL method](https://render.com/docs/deploy-hooks) to deploy.

Succeed:

![image](https://github.com/user-attachments/assets/48176e08-0485-451a-bd21-6c9a2d0caa0e)
