### PR TITLE
test(api-rust): fix axum-test constructor after v19 update

### DIFF
--- a/api/api-rust/src/handlers/get_root_test.rs
+++ b/api/api-rust/src/handlers/get_root_test.rs
@@ -7,7 +7,7 @@ use crate::handlers::get_root::get_root;
 #[tokio::test]
 async fn test_root_handler() {
     let app = Router::new().route("/", get(get_root));
-    let server = TestServer::new(app).expect("Failed to create TestServer");
+    let server = TestServer::new(app);
 
     let response = server.get("/").await;
     response.assert_status_ok();


### PR DESCRIPTION
Updates `api/api-rust/src/handlers/get_root_test.rs` to fix the test build failure after the `axum-test` v19 update in PR #39576.

---
*PR created automatically by Jules for task [16909263213921725879](https://jules.google.com/task/16909263213921725879) started by @hongbo-miao*