### PR TITLE
fix: update transitive mlx-swift dependency to resolve build errors

### DIFF
--- a/mobile/mobile-ios/Tuist/Package.resolved
+++ b/mobile/mobile-ios/Tuist/Package.resolved
@@ -1,132 +1,132 @@
 {
-  "originHash" : "7c9c1048ba08ca2533bd4c6d7c6bec09cc52e3c042847479d4ace039f880733a",
-  "pins" : [
+  "originHash": "7c9c1048ba08ca2533bd4c6d7c6bec09cc52e3c042847479d4ace039f880733a",
+  "pins": [
     {
-      "identity" : "fluidaudio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/FluidInference/FluidAudio.git",
-      "state" : {
-        "revision" : "915a392a3b214205fcf4860cc3608bde35891d03",
-        "version" : "0.9.1"
+      "identity": "fluidaudio",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/FluidInference/FluidAudio.git",
+      "state": {
+        "revision": "915a392a3b214205fcf4860cc3608bde35891d03",
+        "version": "0.9.1"
       }
     },
     {
-      "identity" : "kokoro-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlalma/kokoro-ios.git",
-      "state" : {
-        "revision" : "9a1e2614e5898106d00eec7fd21ff2fc89d805a6",
-        "version" : "1.0.10"
+      "identity": "kokoro-ios",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/mlalma/kokoro-ios.git",
+      "state": {
+        "revision": "9a1e2614e5898106d00eec7fd21ff2fc89d805a6",
+        "version": "1.0.10"
       }
     },
     {
-      "identity" : "misakiswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlalma/MisakiSwift",
-      "state" : {
-        "revision" : "dd594b87dcf7b2a9915be09ca44d38172e7c9dab",
-        "version" : "1.0.4"
+      "identity": "misakiswift",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/mlalma/MisakiSwift",
+      "state": {
+        "revision": "dd594b87dcf7b2a9915be09ca44d38172e7c9dab",
+        "version": "1.0.4"
       }
     },
     {
-      "identity" : "ml-stable-diffusion",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/ml-stable-diffusion.git",
-      "state" : {
-        "revision" : "5a170d29cf38e674b80541d7ce22929c6a11cdde",
-        "version" : "1.1.1"
+      "identity": "ml-stable-diffusion",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/ml-stable-diffusion.git",
+      "state": {
+        "revision": "5a170d29cf38e674b80541d7ce22929c6a11cdde",
+        "version": "1.1.1"
       }
     },
     {
-      "identity" : "mlx-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift",
-      "state" : {
-        "revision" : "072b684acaae80b6a463abab3a103732f33774bf",
-        "version" : "0.29.1"
+      "identity": "mlx-swift",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ml-explore/mlx-swift",
+      "state": {
+        "revision": "6ba4827fb82c97d012eec9ab4b2de21f85c3b33d",
+        "version": "0.30.6"
       }
     },
     {
-      "identity" : "mlx-swift-lm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm",
-      "state" : {
-        "revision" : "7e19e09027923d89ac47dd087d9627f610e5a91a",
-        "version" : "2.30.6"
+      "identity": "mlx-swift-lm",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ml-explore/mlx-swift-lm",
+      "state": {
+        "revision": "7e19e09027923d89ac47dd087d9627f610e5a91a",
+        "version": "2.30.6"
       }
     },
     {
-      "identity" : "mlxutilslibrary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlalma/MLXUtilsLibrary.git",
-      "state" : {
-        "revision" : "41f6cfd5d68b65aa3c65a34efe3b71c371ed915b",
-        "version" : "0.0.6"
+      "identity": "mlxutilslibrary",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/mlalma/MLXUtilsLibrary.git",
+      "state": {
+        "revision": "41f6cfd5d68b65aa3c65a34efe3b71c371ed915b",
+        "version": "0.0.6"
       }
     },
     {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
-        "version" : "1.4.0"
+      "identity": "swift-argument-parser",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-argument-parser.git",
+      "state": {
+        "revision": "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version": "1.4.0"
       }
     },
     {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+      "identity": "swift-collections",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-collections.git",
+      "state": {
+        "revision": "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version": "1.3.0"
       }
     },
     {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "38b7beeec5d968accd19a8a70c1882cc89979d1c",
-        "version" : "2.1.1"
+      "identity": "swift-jinja",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/huggingface/swift-jinja.git",
+      "state": {
+        "revision": "38b7beeec5d968accd19a8a70c1882cc89979d1c",
+        "version": "2.1.1"
       }
     },
     {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
+      "identity": "swift-numerics",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-numerics",
+      "state": {
+        "revision": "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version": "1.1.1"
       }
     },
     {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers.git",
-      "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
+      "identity": "swift-transformers",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/huggingface/swift-transformers.git",
+      "state": {
+        "revision": "150169bfba0889c229a2ce7494cf8949f18e6906",
+        "version": "1.1.9"
       }
     },
     {
-      "identity" : "whisperkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/argmaxinc/WhisperKit",
-      "state" : {
-        "revision" : "664e1b5a65296cd957dfdf262cd120ca88f3b24b",
-        "version" : "0.15.0"
+      "identity": "whisperkit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/argmaxinc/WhisperKit",
+      "state": {
+        "revision": "664e1b5a65296cd957dfdf262cd120ca88f3b24b",
+        "version": "0.15.0"
       }
     },
     {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation.git",
-      "state" : {
-        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
-        "version" : "0.9.20"
+      "identity": "zipfoundation",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/weichsel/ZIPFoundation.git",
+      "state": {
+        "revision": "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version": "0.9.20"
       }
     }
   ],
-  "version" : 3
+  "version": 3
 }

--- a/mobile/mobile-ios/Tuist/Package.resolved
+++ b/mobile/mobile-ios/Tuist/Package.resolved
@@ -15,8 +15,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/mlalma/kokoro-ios.git",
       "state": {
-        "revision": "9a1e2614e5898106d00eec7fd21ff2fc89d805a6",
-        "version": "1.0.10"
+        "revision": "4d6d1d8ff8cd012014180c9cd4cf0151e7682354",
+        "version": "1.0.11"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/mlalma/MisakiSwift",
       "state": {
-        "revision": "dd594b87dcf7b2a9915be09ca44d38172e7c9dab",
-        "version": "1.0.4"
+        "revision": "6835a1ce4a8854075c89f18ff75c74b13ef58e15",
+        "version": "1.0.6"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/mlalma/MLXUtilsLibrary.git",
       "state": {
-        "revision": "41f6cfd5d68b65aa3c65a34efe3b71c371ed915b",
-        "version": "0.0.6"
+        "revision": "66f7cd58026f335c46699f0f8030cb3bda495c54",
+        "version": "0.0.7"
       }
     },
     {

--- a/mobile/mobile-ios/Tuist/Package.resolved
+++ b/mobile/mobile-ios/Tuist/Package.resolved
@@ -15,8 +15,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/mlalma/kokoro-ios.git",
       "state": {
-        "revision": "4d6d1d8ff8cd012014180c9cd4cf0151e7682354",
-        "version": "1.0.11"
+        "revision": "9a1e2614e5898106d00eec7fd21ff2fc89d805a6",
+        "version": "1.0.10"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/mlalma/MisakiSwift",
       "state": {
-        "revision": "6835a1ce4a8854075c89f18ff75c74b13ef58e15",
-        "version": "1.0.6"
+        "revision": "dd594b87dcf7b2a9915be09ca44d38172e7c9dab",
+        "version": "1.0.4"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/mlalma/MLXUtilsLibrary.git",
       "state": {
-        "revision": "66f7cd58026f335c46699f0f8030cb3bda495c54",
-        "version": "0.0.7"
+        "revision": "41f6cfd5d68b65aa3c65a34efe3b71c371ed915b",
+        "version": "0.0.6"
       }
     },
     {

--- a/mobile/mobile-ios/Tuist/Package.swift
+++ b/mobile/mobile-ios/Tuist/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     .package(url: "https://github.com/argmaxinc/WhisperKit", from: "0.15.0"),
     .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.9"),
     .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "2.30.6"),
-    .package(url: "https://github.com/mlalma/kokoro-ios", from: "1.0.10"),
+    .package(url: "https://github.com/mlalma/kokoro-ios", from: "1.0.11"),
     .package(url: "https://github.com/apple/ml-stable-diffusion.git", from: "1.1.1"),
   ]
 )

--- a/mobile/mobile-ios/Tuist/Package.swift
+++ b/mobile/mobile-ios/Tuist/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     .package(url: "https://github.com/argmaxinc/WhisperKit", from: "0.15.0"),
     .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.9"),
     .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "2.30.6"),
-    .package(url: "https://github.com/mlalma/kokoro-ios", from: "1.0.11"),
+    .package(url: "https://github.com/mlalma/kokoro-ios", from: "1.0.10"),
     .package(url: "https://github.com/apple/ml-stable-diffusion.git", from: "1.1.1"),
   ]
 )


### PR DESCRIPTION
Resolves build errors in #38329 caused by `mlx-swift-lm` 2.30.6 requiring `mlx-swift` 0.30.6. The transitive dependency `mlx-swift` was correctly resolved to version `0.30.6` (revision `6ba4827fb82c97d012eec9ab4b2de21f85c3b33d`) in `Package.resolved` to ensure the project builds correctly.

---
*PR created automatically by Jules for task [16636764932123463667](https://jules.google.com/task/16636764932123463667) started by @hongbo-miao*