### PR TITLE
fix(hm-imagebind): cast image paths to string for gradio 6.9.0 compat

### DIFF
--- a/embedding/hm-imagebind/src/main.py
+++ b/embedding/hm-imagebind/src/main.py
@@ -136,7 +136,7 @@ class ImageBindSearch:
     ) -> gr.TabbedInterface:
         image_to_text_audio = gr.Interface(
             fn=self.search_by_image,
-            inputs=gr.Image(type="filepath", value=image_paths[0]),
+            inputs=gr.Image(type="filepath", value=str(image_paths[0])),
             outputs=[gr.Text(label="Output Text"), gr.Audio(label="Output Audio")],
             examples=image_paths,
             flagging_mode="never",


### PR DESCRIPTION
Upgrading gradio to version 6.9.0 caused an error due to tighter type constraints on `gr.Image(value=...)` which previously accepted `pathlib.Path` objects but now explicitly expects strings, PIL Images, or arrays. 

This PR simply casts `image_paths[0]` to `str(image_paths[0])` when passed to `gr.Image`, ensuring type checking passes in MyPy and no runtime errors occur.

---
*PR created automatically by Jules for task [8861367409240545095](https://jules.google.com/task/8861367409240545095) started by @hongbo-miao*