### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/kubernetes/argo-cd/projects/nebius/production-hm/trino-rabbit/environments/production/helm-chart/values.yaml
+++ b/kubernetes/argo-cd/projects/nebius/production-hm/trino-rabbit/environments/production/helm-chart/values.yaml
@@ -114,7 +114,7 @@ jmx:
   enabled: true
   exporter:
     enabled: true
-    image: harbor.hongbomiao.com/docker-hub-proxy-cache/bitnamilegacy/jmx-exporter:1.4.0
+    image: harbor.hongbomiao.com/docker-hub-proxy-cache/soldevelo/jmx-exporter:1.4.0
     resources:
       requests:
         cpu: 30m

--- a/kubernetes/argo-cd/projects/nebius/production-hm/trino-rabbit/environments/production/helm-chart/values.yaml
+++ b/kubernetes/argo-cd/projects/nebius/production-hm/trino-rabbit/environments/production/helm-chart/values.yaml
@@ -114,7 +114,7 @@ jmx:
   enabled: true
   exporter:
     enabled: true
-    image: harbor.hongbomiao.com/docker-hub-proxy-cache/soldevelo/jmx-exporter:1.4.0
+    image: docker.io/soldevelo/jmx-exporter:1.4.0
     resources:
       requests:
         cpu: 30m


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnamilegacy/jmx-exporter:1.4.0` → [`soldevelo/jmx-exporter:1.4.0`](https://hub.docker.com/r/soldevelo/jmx-exporter)